### PR TITLE
fix: added support for changing between unicode and ascii

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
-# rconpp
+# rcon++
 Rcon++ is a modern Source RCON library for C++, allowing people to easily use RCON however they like!
 
 #### Library Features
 
 - Support for Valve and non-Valve games.
 - Non-blocking and blocking calls.
+- Header-Only (all in one file)!
 
 #### To-do
 
 - Support for hosting an RCON server.
 - Support for multiple response packets.
-- Make the project header-Only (all in one file).
 
 #### Library Usage
 
@@ -23,24 +23,25 @@ If you're using this library, feel free to message me and show me, you might jus
 
 ### Linux and Unix
 
-This library was originally made and tested on these operating systems and will work perfectly on these!
+This library was originally made and tested on Linux & UNIX (more specifically OSX) and will work perfectly on these!
 
 ### Windows
 
-Windows support has been added but is still under heavy testing.
+Windows is fully supported and tested! We natively support MSVC and clang-cl, but not MinGW.
+We do not test support for MinGW, nor do we want to actively try and support it. You can try MinGW at your own risk.
 
 # Getting Started
 
-Rcon++ can only be used by adding the header and cpp file into your source code.
+For now, rcon++ can only be used by adding the header and cpp file into your source code.
 
-From there you can easily start an RCON connection with the following:
+From there you can easily start an RCON connection, and do a command, like the following:
 
 ```c++
 #include <iostream>
-#include <rcon.h>
+#include "rcon.h"
 
 int main() {
-        rcon::rcon rcon_client(127.0.0.1, 27015, changeme);
+        rcon::rcon rcon_client("127.0.0.1", 27015, "changeme");
         rcon_client.send_data("Hello!", 3, data_type::SERVERDATA_EXECCOMMAND, [](const rcon_response& response) {
                 std::cout << "response: " << response.data << "\n";
         });

--- a/include/rconpp/rcon.h
+++ b/include/rconpp/rcon.h
@@ -77,7 +77,7 @@ class rcon {
 
 	std::thread queue_runner;
 
-public:
+	public:
 
 	/**
 	 * @brief rcon constuctor. Initiates a connection to an RCON server with the parameters given.
@@ -193,7 +193,7 @@ public:
 		return receive_information(id, type);
 	}
 
-private:
+	private:
 
 	/**
 	 * @brief Connects to RCON using `address`, `port`, and `password`.
@@ -231,7 +231,11 @@ private:
 		struct sockaddr_in server {};
 		server.sin_family = AF_INET;
 #ifdef _WIN32
+		#ifdef UNICODE
 		InetPton(AF_INET, std::wstring(address.begin(), address.end()).c_str(), &server.sin_addr.s_addr);
+	#else
+		InetPton(AF_INET, address.c_str(), &server.sin_addr.s_addr);
+	#endif
 #else
 		server.sin_addr.s_addr = inet_addr(address.c_str());
 #endif
@@ -266,7 +270,7 @@ private:
 	 * @param id The ID of the request.
 	 * @param type The type of packet.
 	 *
-	 * @returns an std::vector<char>
+	 * @returns The packet data (as an array of chars) to send to a server.
 	 */
 	std::vector<char> form_packet(const std::string_view data, int32_t id, int32_t type) {
 		const int32_t data_size = static_cast<int32_t>(data.size()) + MIN_PACKET_SIZE;

--- a/include/rconpp/rcon.h
+++ b/include/rconpp/rcon.h
@@ -77,7 +77,7 @@ class rcon {
 
 	std::thread queue_runner;
 
-	public:
+public:
 
 	/**
 	 * @brief rcon constuctor. Initiates a connection to an RCON server with the parameters given.
@@ -193,7 +193,7 @@ class rcon {
 		return receive_information(id, type);
 	}
 
-	private:
+private:
 
 	/**
 	 * @brief Connects to RCON using `address`, `port`, and `password`.
@@ -231,7 +231,7 @@ class rcon {
 		struct sockaddr_in server {};
 		server.sin_family = AF_INET;
 #ifdef _WIN32
-		#ifdef UNICODE
+	#ifdef UNICODE
 		InetPton(AF_INET, std::wstring(address.begin(), address.end()).c_str(), &server.sin_addr.s_addr);
 	#else
 		InetPton(AF_INET, address.c_str(), &server.sin_addr.s_addr);


### PR DESCRIPTION
This PR fixes an issue where a project using ASCII would throw errors due to `InetPton` changing parameter types if the project was UNICODE or not.