### PR TITLE
fix: client crashes a program after destructor is called

### DIFF
--- a/include/rconpp/client.h
+++ b/include/rconpp/client.h
@@ -16,6 +16,7 @@
 #include <vector>
 #include <iostream>
 #include <cstring>
+#include <atomic>
 #include <thread>
 #include <condition_variable>
 #include "utilities.h"
@@ -44,7 +45,7 @@ class RCONPP_EXPORT rcon_client {
 	std::thread queue_runner;
 
 public:
-	bool connected{false};
+	std::atomic<bool> connected{false};
 
 	std::function<void(const std::string_view& log)> on_log;
 

--- a/src/rconpp/client.cpp
+++ b/src/rconpp/client.cpp
@@ -241,10 +241,6 @@ void rconpp::rcon_client::start(bool return_after) {
 			}
 
 			for (const queued_request& request : requests_queued) {
-				// If we're closing the connection down, we need to back out.
-				if(!connected)
-					return;
-
 				// Send data to callback if it's been set.
 				if (request.callback)
 					request.callback(send_data_sync(request.data, request.id, request.type));
@@ -255,8 +251,6 @@ void rconpp::rcon_client::start(bool return_after) {
 			requests_queued.clear();
 		}
 	});
-
-	queue_runner.detach();
 
 	if(!return_after) {
 		block_calling_thread();


### PR DESCRIPTION
 I am using your library as follows:
```
int getPlayersCount() {
    static int id = 3;
    int result = -1;

    rconpp::rcon_client client(rcon_credentials.ip, rcon_credentials.port, rcon_credentials.password);
    client.on_log = [](const std::string_view& log) { std::cout << log << std::endl; };
    client.start(true);
    if (client.connected) {
        auto response = client.send_data_sync("list", ++id, rconpp::data_type::SERVERDATA_EXECCOMMAND);
        /* ... */
        std::cout << response.data << std::endl;
    }

    return result;
}
```

```
int main() {
    ABMinecraft minecraft(Settings::rcon_credentials);
    minecraft.getPlayersCount();
    std::cout << "exited getPlayersCount(), rcon_client is destructed" << std::endl;
    while (true) {
    }
}
```
The program crashes a moment after the rcon_client is destructed:
I think the problem is that `queue_runner` uses `this->connected` after the rcon_client object is destructed, and even if `bool connected` was set to false in the destructor, it may not be false after the memory is freed.

For a possible fix, see PR.
